### PR TITLE
Update POM maven-compiler-plugin to 1.7 source/target language level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
 				<configuration>
 					<verbose>true</verbose>
 					<fork>true</fork>
+          <source>1.7</source>
+          <target>1.7</target>
 					<executable><!-- path-to-javac -->
 					</executable>
 					<compilerVersion>1.7</compilerVersion>


### PR DESCRIPTION
I update POM to 1.7 source/target language level, otherwise maven build failed with compiler error:
[INFO] Compilation failure
Z:\projects\development\htm.java\src\main\java\org\numenta\nupic\util\Tuple.java:[28,33] error: inconvertible types
