### PR TITLE
testing the RNG is not part of the scope 

### DIFF
--- a/src/test/java/org/numenta/nupic/encoders/RandomDistributedScalarEncoderTest.java
+++ b/src/test/java/org/numenta/nupic/encoders/RandomDistributedScalarEncoderTest.java
@@ -275,8 +275,11 @@ public class RandomDistributedScalarEncoderTest {
 				is(equalTo(e2)));
 		assertThat("Different seeds gives rise to same encodings", e1,
 				is(not(equalTo(e3))));
-		assertThat("seeds of -1 give rise to same encodings", e4,
-				is(not(equalTo(e3))));
+		//Removing this test because testing the RNG is not part of the scope of
+		//this test - and we cannot assure that the RNG will initialize the default
+		//seed to different values.
+		//assertThat("seeds of -1 give rise to same encodings", e4,
+		//		is(not(equalTo(e3))));
 	}
 
 	@Test


### PR DESCRIPTION
Removing one test because testing the RNG is not part of the scope of this test - and we cannot assure that the RNG will initialize the default seed to different values.

fixes #167 