### PR TITLE
if condition corrected to check NaN for minVal and maxVal

### DIFF
--- a/src/main/java/org/numenta/nupic/encoders/ScalarEncoder.java
+++ b/src/main/java/org/numenta/nupic/encoders/ScalarEncoder.java
@@ -216,7 +216,7 @@ public class ScalarEncoder extends Encoder<Double> {
 	    // bits to the right of the center bit of maxval
 		setPadding(isPeriodic() ? 0 : getHalfWidth());
 
-		if(!Double.isNaN(getMinVal()) && !Double.isNaN(getMinVal())) {
+		if(!Double.isNaN(getMinVal()) && !Double.isNaN(getMaxVal())) {
 			if(getMinVal() >= getMaxVal()) {
 				throw new IllegalStateException("maxVal must be > minVal");
 			}


### PR DESCRIPTION
The if condition was checking if minVal is an NaN twice instead of checking for minVal and maxVal. Hence, made the correction.

Fixes #201 