### PR TITLE
Fixed ResourceLocator bug returning wrong resource locations on Windows

### DIFF
--- a/src/main/java/org/numenta/nupic/datagen/ResourceLocator.java
+++ b/src/main/java/org/numenta/nupic/datagen/ResourceLocator.java
@@ -25,7 +25,7 @@ public interface ResourceLocator {
         if(url == null) {
             url = ResourceLocator.class.getClassLoader().getResource(s);
         }
-        return url.getPath();
+        return new File(url.getPath()).getPath();
     }
     
     public static String locate(String s) {


### PR DESCRIPTION
Fixes #225

The unit test org.numenta.nupic.network.sensor.BatchedCsvStreamTest failed on my Windows machine.

The error was caused by a leading slash at the beginning of the URL returned by org.numenta.nupic.datagen.ResourceLocator.java:

```
java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Users/Helge/Development/projects/src/htm.java/build/resources/test/rec-center-hourly.csv
	at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
```
(The error message is a bit irritating, the problem is /C:/... which should be C:/...)

The fix works fine on both Windows and Linux.