### PR TITLE
Classifier fixes, Layer fixes, Tuple speedup

### DIFF
--- a/src/main/java/org/numenta/nupic/Connections.java
+++ b/src/main/java/org/numenta/nupic/Connections.java
@@ -137,7 +137,7 @@ public class Connections {
     protected Set<Cell> activeCells = new LinkedHashSet<Cell>();
     protected Set<Cell> winnerCells = new LinkedHashSet<Cell>();
     protected Set<Cell> predictiveCells = new LinkedHashSet<Cell>();
-    protected Set<Column> predictedColumns = new LinkedHashSet<Column>();
+    protected Set<Column> successfullyPredictedColumns = new LinkedHashSet<Column>();
     protected Set<DistalDendrite> activeSegments = new LinkedHashSet<DistalDendrite>();
     protected Set<DistalDendrite> learningSegments = new LinkedHashSet<DistalDendrite>();
     protected Map<DistalDendrite, Set<Synapse>> activeSynapsesForSegment = new LinkedHashMap<DistalDendrite, Set<Synapse>>();
@@ -228,7 +228,7 @@ public class Connections {
         activeCells.clear();
         winnerCells.clear();
         predictiveCells.clear();
-        predictedColumns.clear();
+        successfullyPredictedColumns.clear();
         activeSegments.clear();
         learningSegments.clear();
         activeSynapsesForSegment.clear();
@@ -1138,20 +1138,20 @@ public class Connections {
     }
     
     /**
-     * Returns the current {@link Set} of predicted columns
+     * Returns the {@link Set} of columns successfully predicted from t - 1.
      * 
      * @return  the current {@link Set} of predicted columns
      */
-    public Set<Column> getPredictedColumns() {
-        return predictedColumns;
+    public Set<Column> getSuccessfullyPredictedColumns() {
+        return successfullyPredictedColumns;
     }
     
     /**
-     * Sets the {@link Set} of predictedColumns
+     * Sets the {@link Set} of columns successfully predicted from t - 1.
      * @param columns
      */
-    public void setPredictedColumns(Set<Column> columns) {
-    	this.predictedColumns = columns;
+    public void setSuccessfullyPredictedColumns(Set<Column> columns) {
+    	this.successfullyPredictedColumns = columns;
     }
     
     /**

--- a/src/main/java/org/numenta/nupic/algorithms/CLAClassifier.java
+++ b/src/main/java/org/numenta/nupic/algorithms/CLAClassifier.java
@@ -142,7 +142,7 @@ public class CLAClassifier {
 		this.actValueAlpha = actValueAlpha;
 		this.verbosity = verbosity;
 		actualValues.add(null);
-		patternNZHistory = new Deque<Tuple>(steps.size() + 1);
+		patternNZHistory = new Deque<Tuple>(ArrayUtils.max(steps.toArray()) + 1);
 	}
 	
 	/**
@@ -251,8 +251,7 @@ public class CLAClassifier {
 			        // buckets equally likely. There is no actual prediction for this
 			        // timestep so any of the possible predictions are just as good.
 					if(sumVotes.length > 0) {
-						Arrays.fill(sumVotes, 1);
-						sumVotes = ArrayUtils.divide(sumVotes, sumVotes.length);
+						Arrays.fill(sumVotes, 1.0 / (double)sumVotes.length);
 					}
 				}
 				

--- a/src/main/java/org/numenta/nupic/network/Layer.java
+++ b/src/main/java/org/numenta/nupic/network/Layer.java
@@ -975,6 +975,27 @@ public class Layer<T> {
         recordNum = 0;
         return this;
     }
+    
+    /**
+     * Resets the {@link TemporalMemory} if it exists.
+     * @return
+     */
+    public void reset() {
+        if(temporalMemory == null) {
+            LOGGER.debug("Attempt to reset Layer: " + getName() + "without TemporalMemory");
+        }else{
+            temporalMemory.reset(connections);
+        }
+    }
+    
+    /**
+     * Returns a flag indicating whether this {@code Layer} contains
+     * a {@link TemporalMemory}.
+     * @return
+     */
+    public boolean hasTemporalMemory() {
+        return temporalMemory != null;
+    }
 
     /**
      * Increments the current record sequence number.

--- a/src/main/java/org/numenta/nupic/network/Layer.java
+++ b/src/main/java/org/numenta/nupic/network/Layer.java
@@ -623,7 +623,7 @@ public class Layer<T> {
         
         this.algo_content_mask |= TEMPORAL_MEMORY;
         this.temporalMemory = tm;
-        temporalMemory.init(connections);
+        
         return this;
     }
 

--- a/src/main/java/org/numenta/nupic/network/Layer.java
+++ b/src/main/java/org/numenta/nupic/network/Layer.java
@@ -985,6 +985,7 @@ public class Layer<T> {
             LOGGER.debug("Attempt to reset Layer: " + getName() + "without TemporalMemory");
         }else{
             temporalMemory.reset(connections);
+            resetRecordNum();
         }
     }
     

--- a/src/main/java/org/numenta/nupic/network/Network.java
+++ b/src/main/java/org/numenta/nupic/network/Network.java
@@ -280,6 +280,25 @@ public class Network {
         // TODO Auto-generated method stub
         return null;
     }
+    
+    /**
+     * Finds any {@link Region} containing a {@link Layer} which contains a {@link TemporalMemory} 
+     * and resets them.
+     */
+    public void reset() {
+        for(Region r : regions) {
+            r.reset();
+        }
+    }
+    
+    /**
+     * Resets the recordNum in all {@link Region}s.
+     */
+    public void resetRecordNum() {
+        for(Region r : regions) {
+            r.resetRecordNum();
+        }
+    }
 
     /**
      * Returns an {@link Observable} capable of emitting {@link Inference}s

--- a/src/main/java/org/numenta/nupic/network/Region.java
+++ b/src/main/java/org/numenta/nupic/network/Region.java
@@ -273,6 +273,27 @@ public class Region {
     }
     
     /**
+     * Finds any {@link Layer} containing a {@link TemporalMemory} 
+     * and resets them.
+     */
+    public void reset() {
+        for(Layer<?> l : layers.values()) {
+            if(l.hasTemporalMemory()) {
+                l.reset();
+            }
+        }
+    }
+    
+    /**
+     * Resets the recordNum in all {@link Layer}s.
+     */
+    public void resetRecordNum() {
+        for(Layer<?> l : layers.values()) {
+            l.resetRecordNum();
+        }
+    }
+    
+    /**
      * Connects the output of the specified {@code Region} to the 
      * input of this Region
      * 

--- a/src/main/java/org/numenta/nupic/research/ComputeCycle.java
+++ b/src/main/java/org/numenta/nupic/research/ComputeCycle.java
@@ -46,7 +46,7 @@ public class ComputeCycle {
     Set<Cell> activeCells = new LinkedHashSet<Cell>();
     Set<Cell> winnerCells = new LinkedHashSet<Cell>();
     Set<Cell> predictiveCells = new LinkedHashSet<Cell>();
-    Set<Column> predictedColumns = new LinkedHashSet<Column>();
+    Set<Column> successfullyPredictedColumns = new LinkedHashSet<Column>();
     Set<DistalDendrite> activeSegments = new LinkedHashSet<DistalDendrite>();
     Set<DistalDendrite> learningSegments = new LinkedHashSet<DistalDendrite>();
     Map<DistalDendrite, Set<Synapse>> activeSynapsesForSegment = new LinkedHashMap<DistalDendrite, Set<Synapse>>();
@@ -68,7 +68,7 @@ public class ComputeCycle {
         this.activeCells = new LinkedHashSet<Cell>(c.getActiveCells());
         this.winnerCells = new LinkedHashSet<Cell>(c.getWinnerCells());
         this.predictiveCells = new LinkedHashSet<Cell>(c.getPredictiveCells());
-        this.predictedColumns = new LinkedHashSet<Column>(c.getPredictedColumns());
+        this.successfullyPredictedColumns = new LinkedHashSet<Column>(c.getSuccessfullyPredictedColumns());
         this.activeSegments = new LinkedHashSet<DistalDendrite>(c.getActiveSegments());
         this.learningSegments = new LinkedHashSet<DistalDendrite>(c.getLearningSegments());
         this.activeSynapsesForSegment = new LinkedHashMap<DistalDendrite, Set<Synapse>>(c.getActiveSynapsesForSegment());
@@ -101,12 +101,12 @@ public class ComputeCycle {
     }
     
     /**
-     * Returns the current {@link Set} of predicted columns
+     * Returns the {@link Set} of columns successfully predicted from t - 1.
      * 
      * @return  the current {@link Set} of predicted columns
      */
-    public Set<Column> predictedColumns() {
-        return predictedColumns;
+    public Set<Column> successfullyPredictedColumns() {
+        return successfullyPredictedColumns;
     }
     
     /**

--- a/src/main/java/org/numenta/nupic/research/TemporalMemory.java
+++ b/src/main/java/org/numenta/nupic/research/TemporalMemory.java
@@ -107,7 +107,7 @@ public class TemporalMemory {
         connections.setActiveCells(result.activeCells());
         connections.setWinnerCells(result.winnerCells());
         connections.setPredictiveCells(result.predictiveCells());
-        connections.setPredictedColumns(result.predictedColumns());
+        connections.setSuccessfullyPredictedColumns(result.successfullyPredictedColumns());
         connections.setActiveSegments(result.activeSegments());
         connections.setLearningSegments(result.learningSegments());
         connections.setActiveSynapsesForSegment(result.activeSynapsesForSegment());
@@ -135,7 +135,7 @@ public class TemporalMemory {
         
         activateCorrectlyPredictiveCells(cycle, prevPredictiveCells, activeColumns);
         
-        burstColumns(cycle, c, activeColumns, cycle.predictedColumns, prevActiveSynapsesForSegment);
+        burstColumns(cycle, c, activeColumns, cycle.successfullyPredictedColumns, prevActiveSynapsesForSegment);
         
         if(learn) {
             learnOnSegments(c, prevActiveSegments, cycle.learningSegments, prevActiveSynapsesForSegment, cycle.winnerCells, prevWinnerCells);
@@ -169,7 +169,7 @@ public class TemporalMemory {
             if(activeColumns.contains(column)) {
                 c.activeCells.add(cell);
                 c.winnerCells.add(cell);
-                c.predictedColumns.add(column);
+                c.successfullyPredictedColumns.add(column);
             }
         }
     }

--- a/src/main/java/org/numenta/nupic/util/NamedTuple.java
+++ b/src/main/java/org/numenta/nupic/util/NamedTuple.java
@@ -35,6 +35,7 @@ public class NamedTuple extends Tuple {
     String[] keys;
     
     int hash;
+    int thisHashcode;
     
     private static final String[] EMPTY_KEYS = {};
     
@@ -61,6 +62,8 @@ public class NamedTuple extends Tuple {
         for(int i = 0;i < keys.length;i++) {
             addEntry(keys[i], objects[i]);
         }
+        
+        this.thisHashcode = hashCode();
     }
     
     /**
@@ -169,7 +172,7 @@ public class NamedTuple extends Tuple {
         if(!super.equals(obj))
             return false;
         NamedTuple other = (NamedTuple)obj;
-        if(!Arrays.equals(entries, other.entries))
+        if(this.thisHashcode != other.thisHashcode)
             return false;
         return true;
     }

--- a/src/main/java/org/numenta/nupic/util/Tuple.java
+++ b/src/main/java/org/numenta/nupic/util/Tuple.java
@@ -37,6 +37,8 @@ public class Tuple {
     /** The internal container array */
 	protected Object[] container;
 	
+	private int hashcode;
+	
 	/**
 	 * Instantiates a new {@code Tuple}
 	 * @param objects
@@ -44,6 +46,7 @@ public class Tuple {
 	public Tuple(Object... objects) {
 		container = new Object[objects.length];
 		for(int i = 0;i < objects.length;i++) container[i] = objects[i];
+		this.hashcode = hashCode();
 	}
 	
 	/**
@@ -115,7 +118,7 @@ public class Tuple {
 		if (getClass() != obj.getClass())
 			return false;
 		Tuple other = (Tuple) obj;
-		if (!Arrays.equals(container, other.container))
+		if (this.hashcode != other.hashcode)
 			return false;
 		return true;
 	}

--- a/src/test/java/org/numenta/nupic/research/TemporalMemoryTest.java
+++ b/src/test/java/org/numenta/nupic/research/TemporalMemoryTest.java
@@ -67,7 +67,7 @@ public class TemporalMemoryTest {
         tm.activateCorrectlyPredictiveCells(c, cn.getCellSet(prevPredictiveCells), cn.getColumnSet(activeColumns));
         Set<Cell> activeCells = cn.getActiveCells();
         Set<Cell> winnerCells = cn.getWinnerCells();
-        Set<Column> predictedColumns = cn.getPredictedColumns();
+        Set<Column> predictedColumns = cn.getSuccessfullyPredictedColumns();
         
         int[] expectedActiveWinners = new int[] { 1026, 26337, 26339 };
         int[] expectedPredictCols = new int[] { 32, 823 };
@@ -99,7 +99,7 @@ public class TemporalMemoryTest {
         tm.activateCorrectlyPredictiveCells(c, cn.getCellSet(prevPredictiveCells), cn.getColumnSet(activeColumns));
         Set<Cell> activeCells = c.activeCells();
         Set<Cell> winnerCells = c.winnerCells();
-        Set<Column> predictedColumns = c.predictedColumns();
+        Set<Column> predictedColumns = c.successfullyPredictedColumns();
         
         assertTrue(activeCells.isEmpty());
         assertTrue(winnerCells.isEmpty());
@@ -112,7 +112,7 @@ public class TemporalMemoryTest {
         tm.activateCorrectlyPredictiveCells(c, cn.getCellSet(prevPredictiveCells), cn.getColumnSet(activeColumns));
         activeCells = c.activeCells();
         winnerCells = c.winnerCells();
-        predictedColumns = c.predictedColumns();
+        predictedColumns = c.successfullyPredictedColumns();
         
         assertTrue(activeCells.isEmpty());
         assertTrue(winnerCells.isEmpty());

--- a/src/test/java/org/numenta/nupic/util/TupleTest.java
+++ b/src/test/java/org/numenta/nupic/util/TupleTest.java
@@ -1,0 +1,31 @@
+package org.numenta.nupic.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+
+public class TupleTest {
+
+    @Test
+    public void testEquality() {
+        Tuple t1 = new Tuple("1", new Double(1));
+        Tuple t2 = new Tuple("1", new Double(1));
+        assertEquals(t1, t2);
+        assertEquals(t1.hashCode(), t2.hashCode());
+        assertTrue(t1.equals(t2));
+        
+        t1 = new Tuple("1", new Double(1));
+        t2 = new Tuple("2", new Double(1));
+        assertNotEquals(t1, t2);
+        assertNotEquals(t1.hashCode(), t2.hashCode());
+        assertFalse(t1.equals(t2));
+        
+        t1 = new Tuple("1", new Double(1));
+        t2 = new Tuple("1", new Double(1), 1);
+        assertNotEquals(t1, t2);
+        assertNotEquals(t1.hashCode(), t2.hashCode());
+        assertFalse(t1.equals(t2));
+    }
+
+}


### PR DESCRIPTION
This commit adds a bunch of fixes, and tune ups - namely:
1. CLAClassifier init fix for multiple steps 
2. Layer class initiated TemporalMemory wrongly.
3. Added ability to reset a Network and reset the record num counter from a Network
4. For immutable Tuples, cache the hashcode and use it for "equals()" method instead of churning through internal objects.

Fixes #233 
Fixes #234 
Fixes #235 
Fixes #236 
Fixes #241 