### PR TITLE
Add a  low memory and fast implementation for input connections matrix.

### DIFF
--- a/src/main/java/org/numenta/nupic/util/ArrayUtils.java
+++ b/src/main/java/org/numenta/nupic/util/ArrayUtils.java
@@ -1307,9 +1307,12 @@ public class ArrayUtils {
      * @return
      */
     public static boolean isSparse(int[] ia) {
-        for(int i = ia.length - 1;i >= 0;i--) {
-            if(ia[i] > 1) return true;
+        for (int i = 0; i < ia.length && i < 3; i++) {
+            if (ia[i] > 1) {
+                return true;
+            }
         }
+        
         return false;
     }
     
@@ -1327,7 +1330,7 @@ public class ArrayUtils {
         Arrays.stream(in).forEach(i -> {retVal[i] = 1;});
         return retVal;
     }
-
+    
     /**
      * Scans the specified values and applies the {@link Condition} to each
      * value, returning the indexes of the values where the condition evaluates
@@ -1722,6 +1725,22 @@ public class ArrayUtils {
             setValue(Array.get(array, indexes[0]), value, tail(indexes));
         }
     }
+    
+    /**
+     * Get <tt>value</tt> for <tt>array</tt> at specified position <tt>indexes</tt>
+     *
+     * @param array
+     * @param indexes
+     */
+    public static Object getValue(Object array, int... indexes) {
+        Object slice = array;
+        for(int i = 0;i < indexes.length;i++) {
+            slice = Array.get(slice, indexes[i]);
+        }
+        
+        return slice;
+    }
+
 
     /**
      *Assigns the specified int value to each element of the specified any dimensional array

--- a/src/main/java/org/numenta/nupic/util/FastConnectionsMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/FastConnectionsMatrix.java
@@ -1,0 +1,133 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2014, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+package org.numenta.nupic.util;
+
+import org.numenta.nupic.Connections;
+
+import gnu.trove.map.hash.TIntByteHashMap;
+
+/**
+ * Fast implementation of {@link SparseBinaryMatrix} for use as ConnectedMatrix in  
+ * {@link Connections}
+ * 
+ * @author Jose Luis Martin
+ */
+public class FastConnectionsMatrix extends SparseBinaryMatrixSupport {
+    
+    private TIntByteHashMap[] columns;
+   
+    /**
+     * @param dimensions
+     */
+    public FastConnectionsMatrix(int[] dimensions) {
+        this(dimensions, false);
+    }
+    
+    /**
+     * @param dimensions
+     * @param useColumnMajorOrdering
+     */
+    public FastConnectionsMatrix(int[] dimensions, boolean useColumnMajorOrdering) {
+        super(dimensions, useColumnMajorOrdering);
+        this.columns = new TIntByteHashMap[dimensions[0]];
+    }
+
+    @Override
+    public Object getSlice(int... coordinates) {
+        if (coordinates.length > this.numDimensions - 1)
+            sliceError(coordinates);
+        
+        int[] slice = new int[this.dimensions[1]];
+        for (int i = 0; i < this.dimensions[1]; i++)
+            slice[i] = this.columns[coordinates[0]].get(i);
+        
+        return slice;
+    }
+
+    @Override
+    public void rightVecSumAtNZ(int[] inputVector, int[] results) {
+        for (int i = 0; i < dimensions[0]; i++) {
+            for (int index : getMap(i).keys()) {
+                if (inputVector[index] != 0)
+                    results[i] += 1;
+            }
+        }
+    }
+
+    @Override
+    public FastConnectionsMatrix set(int index, Object value) {
+       set(index, ((Integer)value).intValue());
+       return this;
+    }
+    
+    @Override
+    public SparseBinaryMatrixSupport set(int value, int... coordinates) {
+        TIntByteHashMap map = getMap(coordinates[0]);
+        if (value == 0) {
+            map.remove(coordinates[1]);
+        }
+        else {
+            map.put(coordinates[1], (byte) value);
+        }
+        
+        return this;
+    }
+    
+    
+
+    @Override
+    public Integer get(int index) {
+        int[] coordinates = computeCoordinates(index);
+        return (int) getMap(coordinates[0]).get(coordinates[1]);
+    }
+
+    /**
+     * @param i
+     */
+    private TIntByteHashMap getMap(int i) {
+        if (this.columns[i] == null)
+            this.columns[i] = new TIntByteHashMap();
+        
+        return this.columns[i];
+        
+    }
+
+    @Override
+    public void clearStatistics(int row) {
+        getMap(row).clear();
+    }
+
+    @Override
+    public int getTrueCount(int index) {
+        return getMap(index).size();
+    }
+
+    @Override
+    public int[] getTrueCounts() {
+        int[] trueCounts = new int[this.dimensions[0]];
+        for (int i = 0; i < this.dimensions[0]; i++) 
+            trueCounts[i] = getTrueCount(i);
+        
+        return trueCounts;
+    }
+}

--- a/src/main/java/org/numenta/nupic/util/FastConnectionsMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/FastConnectionsMatrix.java
@@ -130,4 +130,9 @@ public class FastConnectionsMatrix extends SparseBinaryMatrixSupport {
         
         return trueCounts;
     }
+
+    @Override
+    public SparseBinaryMatrixSupport setForTest(int index, int value) {
+        return set(index, value);
+    }
 }

--- a/src/main/java/org/numenta/nupic/util/FlatArrayMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/FlatArrayMatrix.java
@@ -22,7 +22,6 @@
 
 package org.numenta.nupic.util;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**

--- a/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
@@ -77,10 +77,9 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
     @Override
     public void rightVecSumAtNZ(int[] inputVector, int[] results) {
         if (this.dimensions.length > 1) {
-            for(int i = 0; i < this.dimensions[0]; i++) {
-                for(int j = 0;  j < this.dimensions[1] ; j++) {
-                    results[i] += (inputVector[j] * (int) get(i, j));
-                }
+            for (int value : getSparseIndices()) {
+                int[] coordinates = computeCoordinates(value);
+                results[coordinates[0]] += inputVector[coordinates[1]] * get(value);
             }
         }
         else {

--- a/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
@@ -25,6 +25,9 @@ package org.numenta.nupic.util;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
 /**
  * Low Memory implementation of {@link SparseBinaryMatrix} without 
  * a backing array.
@@ -32,6 +35,8 @@ import java.util.Arrays;
  * @author Jose Luis Martin
  */
 public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
+    
+    private TIntSet sparseSet = new TIntHashSet();
 
     public LowMemorySparseBinaryMatrix(int[] dimensions) {
         this(dimensions, false);
@@ -97,7 +102,15 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
 
     @Override
     public LowMemorySparseBinaryMatrix set(int value, int... coordinates) {
-        super.set(value, coordinates);
+        int index = computeIndex(coordinates);
+                
+        if (value == 1) {
+            this.sparseSet.add(index);
+        }
+        else {
+            this.sparseSet.remove(index);
+        }
+        
         updateTrueCounts(coordinates);
 
         return this;
@@ -105,8 +118,11 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
 
     @Override
     public LowMemorySparseBinaryMatrix setForTest(int index, int value) {
-        if (value > 1) {
-            super.setForTest(index, value);
+        if (value == 1) {
+            this.sparseSet.add(index);
+        }
+        else {
+            this.sparseSet.remove(index);
         }
 
         return this;
@@ -128,5 +144,9 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
         return this;
     }
 
+    @Override
+    public Integer get(int index) {
+       return this.sparseSet.contains(index) ? 1 : 0;
+    }
 
 }

--- a/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
@@ -73,7 +73,7 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
 
         return slice;
     }
-
+    
     @Override
     public void rightVecSumAtNZ(int[] inputVector, int[] results) {
         if (this.dimensions.length > 1) {

--- a/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
@@ -79,7 +79,9 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
         if (this.dimensions.length > 1) {
             for (int value : getSparseIndices()) {
                 int[] coordinates = computeCoordinates(value);
-                results[coordinates[0]] += inputVector[coordinates[1]] * get(value);
+                
+                if (inputVector[coordinates[1]]  != 0)
+                    results[coordinates[0]] += inputVector[coordinates[1]] * get(value);
             }
         }
         else {

--- a/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/LowMemorySparseBinaryMatrix.java
@@ -86,7 +86,7 @@ public class LowMemorySparseBinaryMatrix extends SparseBinaryMatrixSupport {
                 int[] coordinates = computeCoordinates(value);
                 
                 if (inputVector[coordinates[1]]  != 0)
-                    results[coordinates[0]] += inputVector[coordinates[1]] * get(value);
+                    results[coordinates[0]] += 1;
             }
         }
         else {

--- a/src/main/java/org/numenta/nupic/util/SetSparseMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/SetSparseMatrix.java
@@ -22,12 +22,6 @@ public class SetSparseMatrix extends SparseMatrixSupport<Integer> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected int[] values() {
-        return this.indexes.stream().mapToInt(i -> i).toArray();
-    }
-
-    @Override
     public SetSparseMatrix set(int[] coordinates, Integer value) {
         return set(computeIndex(coordinates), value);
 

--- a/src/main/java/org/numenta/nupic/util/SparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/SparseBinaryMatrix.java
@@ -61,10 +61,7 @@ public class SparseBinaryMatrix extends SparseBinaryMatrixSupport {
      */
     @Override
     public Object getSlice(int... coordinates) {
-        Object slice = backingArray;
-        for(int i = 0;i < coordinates.length;i++) {
-            slice = Array.get(slice, coordinates[i]);
-        }
+        Object slice = ArrayUtils.getValue(this.backingArray, coordinates);
         //Ensure return value is of type Array
         if(!slice.getClass().isArray()) {
             sliceError(coordinates);
@@ -109,7 +106,6 @@ public class SparseBinaryMatrix extends SparseBinaryMatrixSupport {
      */
     @Override
     public SparseBinaryMatrixSupport set(int value, int... coordinates) {
-        super.set(value, coordinates);
         back(value, coordinates);
         return this;
     }
@@ -145,4 +141,20 @@ public class SparseBinaryMatrix extends SparseBinaryMatrixSupport {
         return this;
     }
 
+    @Override
+    public Integer get(int index) {
+        int[] coordinates = computeCoordinates(index);
+        if (coordinates.length == 1) {
+            return Array.getInt(this.backingArray, index);
+        }
+        
+        else return (Integer) ArrayUtils.getValue(this.backingArray, coordinates);
+    }
+
+    @Override
+    public SparseBinaryMatrixSupport setForTest(int index, int value) {
+        ArrayUtils.setValue(this.backingArray, value, computeCoordinates(index));
+        return this;
+    }
+   
 }

--- a/src/main/java/org/numenta/nupic/util/SparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/SparseBinaryMatrix.java
@@ -137,13 +137,8 @@ public class SparseBinaryMatrix extends SparseBinaryMatrixSupport {
         super.clearStatistics(row);
         int[] slice = (int[])Array.get(backingArray, row);
         Arrays.fill(slice, 0);
-
-
     }
 
-    /* (non-Javadoc)
-     * @see org.numenta.nupic.util.FlatMatrix#set(int, java.lang.Object)
-     */
     @Override
     public SparseBinaryMatrixSupport set(int index, Object value) {
         set(index, ((Integer) value).intValue());

--- a/src/main/java/org/numenta/nupic/util/SparseBinaryMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/SparseBinaryMatrix.java
@@ -130,7 +130,7 @@ public class SparseBinaryMatrix extends SparseBinaryMatrixSupport {
      * being set
      */
     public void clearStatistics(int row) {
-        super.clearStatistics(row);
+        this.setTrueCount(row, 0);
         int[] slice = (int[])Array.get(backingArray, row);
         Arrays.fill(slice, 0);
     }

--- a/src/main/java/org/numenta/nupic/util/SparseBinaryMatrixSupport.java
+++ b/src/main/java/org/numenta/nupic/util/SparseBinaryMatrixSupport.java
@@ -217,6 +217,9 @@ public abstract class SparseBinaryMatrixSupport extends SparseMatrixSupport {
      */
     public void clearStatistics(int row) {
         trueCounts[row] = 0;
+        
+        for (int index : getSliceIndexes(new int[] { row }))
+            set(index, 0);
     }
 
     /**

--- a/src/main/java/org/numenta/nupic/util/SparseMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/SparseMatrix.java
@@ -59,12 +59,4 @@ public interface SparseMatrix<T> extends FlatMatrix<T>{
      */
     T[] asDense(TypeFactory<T> factory);
 
-    /**
-     * Returns an integer array representing the coordinates of the specified index
-     * in terms of the configuration of this {@code SparseMatrix}.
-     * @param index the flat index to be returned as coordinates
-     * @return  coordinates
-     */
-    int[] computeCoordinates(int index);
-
 }

--- a/src/main/java/org/numenta/nupic/util/SparseMatrixSupport.java
+++ b/src/main/java/org/numenta/nupic/util/SparseMatrixSupport.java
@@ -126,12 +126,6 @@ public abstract class SparseMatrixSupport<T> extends FlatMatrixSupport<T> implem
     protected double getDoubleValue(int index) { return -1.0; }
 
     /**
-     * Returns an outer array of T values.
-     * @return
-     */
-    protected abstract <V> V values();
-
-    /**
      * Returns the T at the index computed from the specified coordinates
      * @param coordinates   the coordinates from which to retrieve the indexed object
      * @return  the indexed object

--- a/src/main/java/org/numenta/nupic/util/SparseObjectMatrix.java
+++ b/src/main/java/org/numenta/nupic/util/SparseObjectMatrix.java
@@ -82,16 +82,6 @@ public class SparseObjectMatrix<T> extends SparseMatrixSupport<T> {
     }
 
     /**
-     * Returns an outer array of T values.
-     * @return
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    protected T[] values() {
-        return (T[]) this.sparseMap.values();
-    }
-
-    /**
      * Returns the T at the specified index.
      * 
      * @param index     the index of the T to return

--- a/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
+++ b/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
@@ -283,4 +283,18 @@ public class SparseBinaryMatrixTest {
         int[] sdr = sm.getSparseIndices();
         assertArrayEquals(expected, sdr);
     }
+    
+    @Test
+    public void testSliceIndexes() {
+        SparseBinaryMatrix sm = new SparseBinaryMatrix(this.dimensions);
+        int[][] expected =  {
+                {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 
+                {10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, 
+                {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}, 
+                {30, 31, 32, 33, 34, 35, 36, 37, 38, 39}, 
+                {40, 41, 42, 43, 44, 45, 46, 47, 48, 49}};
+        
+       for (int i = 0; i < this.dimensions[0]; i++)
+           assertArrayEquals(expected[i], sm.getSliceIndexes(new int[] {i}));
+    }
 }

--- a/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
+++ b/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
@@ -40,6 +40,7 @@ public class SparseBinaryMatrixTest {
     public void testBackingStoreAndSliceAccess() {
         doTestBackingStoreAndSliceAccess(new SparseBinaryMatrix(this.dimensions));
         doTestBackingStoreAndSliceAccess(new LowMemorySparseBinaryMatrix(this.dimensions));
+        doTestBackingStoreAndSliceAccess(new FastConnectionsMatrix(this.dimensions));
     }
 
     private void doTestBackingStoreAndSliceAccess(SparseBinaryMatrixSupport sm) {
@@ -82,6 +83,7 @@ public class SparseBinaryMatrixTest {
     public void testRightVecSumAtNZFast() {
         doTestRightVecSumAtNZFast(new SparseBinaryMatrix(this.dimensions));
         doTestRightVecSumAtNZFast(new LowMemorySparseBinaryMatrix(this.dimensions));
+        doTestRightVecSumAtNZFast(new FastConnectionsMatrix(this.dimensions));
     }
 
     private void doTestRightVecSumAtNZFast(SparseBinaryMatrixSupport sm) {
@@ -149,6 +151,7 @@ public class SparseBinaryMatrixTest {
     public void testSetTrueCount() {
         doTestSetTrueCount(new SparseBinaryMatrix(this.dimensions));
         doTestSetTrueCount(new LowMemorySparseBinaryMatrix(this.dimensions));
+        doTestSetTrueCount(new FastConnectionsMatrix(this.dimensions));
     }
 
     private void doTestSetTrueCount(SparseBinaryMatrixSupport sm) {
@@ -238,6 +241,7 @@ public class SparseBinaryMatrixTest {
         int[] dimensions =  { 5, 2 };
         doTestArraySet(new SparseBinaryMatrix(dimensions));
         doTestArraySet(new LowMemorySparseBinaryMatrix(dimensions));
+        doTestArraySet(new FastConnectionsMatrix(dimensions));
     }
 
     private void doTestArraySet(SparseBinaryMatrixSupport sm) {
@@ -252,6 +256,30 @@ public class SparseBinaryMatrixTest {
         }
 
         assertArrayEquals(expected, dense);
+    }
+    
+    @Test
+    public void testGetSparseIndices() {
+        doTestGetSparseIndices(new SparseBinaryMatrix(this.dimensions));
+        doTestGetSparseIndices(new LowMemorySparseBinaryMatrix(this.dimensions));
+    }
+    
+    private void doTestGetSparseIndices(SparseBinaryMatrixSupport sm) {
+        int[] expected = {0, 5, 11, 16, 22, 27, 33, 38, 44, 49};
+        int[][] values = new int[][]{
+            {1, 0, 0, 0, 0, 1, 0, 0, 0, 0},
+            {0, 1, 0, 0, 0, 0, 1, 0, 0, 0},
+            {0, 0, 1, 0, 0, 0, 0, 1, 0, 0},
+            {0, 0, 0, 1, 0, 0, 0, 0, 1, 0},
+            {0, 0, 0, 0, 1, 0, 0, 0, 0, 1}};
 
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 10; j++) {
+                sm.set(values[i][j], new int[] {i, j});
+            }
+        }
+        
+        int[] sdr = sm.getSparseIndices();
+        assertArrayEquals(expected, sdr);
     }
 }

--- a/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
+++ b/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
@@ -25,6 +25,7 @@ package org.numenta.nupic.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -296,5 +297,39 @@ public class SparseBinaryMatrixTest {
         
        for (int i = 0; i < this.dimensions[0]; i++)
            assertArrayEquals(expected[i], sm.getSliceIndexes(new int[] {i}));
+    }
+    
+    @Test
+    public void testOr() {
+        SparseBinaryMatrix sm = createDefaultMatrix();
+        int[] orBits = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        int[] expected = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        sm.or(orBits);
+        assertArrayEquals(expected, (int[]) sm.getSlice(new int[] {0}));
+    }
+    
+    @Test
+    public void testAll() {
+        SparseBinaryMatrix sm = createDefaultMatrix();
+        int[] all = {0, 5, 11, 16, 22, 27, 33, 38, 44, 49};
+        assertTrue(sm.all(all));
+    }
+    
+    private SparseBinaryMatrix createDefaultMatrix() {
+        SparseBinaryMatrix sm  = new SparseBinaryMatrix(this.dimensions);
+        int[][] values = {
+            {1, 0, 0, 0, 0, 1, 0, 0, 0, 0},
+            {0, 1, 0, 0, 0, 0, 1, 0, 0, 0},
+            {0, 0, 1, 0, 0, 0, 0, 1, 0, 0},
+            {0, 0, 0, 1, 0, 0, 0, 0, 1, 0},
+            {0, 0, 0, 0, 1, 0, 0, 0, 0, 1}};
+        
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 10; j++) {
+                sm.set(values[i][j], new int[] {i, j});
+            }
+        }
+        
+        return sm;
     }
 }

--- a/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
+++ b/src/test/java/org/numenta/nupic/util/SparseBinaryMatrixTest.java
@@ -262,6 +262,7 @@ public class SparseBinaryMatrixTest {
     public void testGetSparseIndices() {
         doTestGetSparseIndices(new SparseBinaryMatrix(this.dimensions));
         doTestGetSparseIndices(new LowMemorySparseBinaryMatrix(this.dimensions));
+        doTestGetSparseIndices(new FastConnectionsMatrix(this.dimensions));
     }
     
     private void doTestGetSparseIndices(SparseBinaryMatrixSupport sm) {


### PR DESCRIPTION
- Add FastConnectionsMatrix for input connections (sparse).
- Remove sparse map from SparseBinaryMatrixSupport.
- Remove sparse map usage from SparseBinaryMatrix.

Fix #355 
