### PR TITLE
Added hourOfWeek to DateEncoder

### DIFF
--- a/src/main/java/org/numenta/nupic/Parameters.java
+++ b/src/main/java/org/numenta/nupic/Parameters.java
@@ -287,6 +287,7 @@ public class Parameters {
         DATEFIELD_WKEND("weekend", Tuple.class),
         DATEFIELD_HOLIDAY("holiday", Tuple.class),
         DATEFIELD_TOFD("timeOfDay", Tuple.class),
+        DATEFIELD_HOW("hourOfWeek", Tuple.class),
         DATEFIELD_CUSTOM("customDays", Tuple.class), // e.g. Tuple(bits:int, List<String>:"mon,tue,fri")
         DATEFIELD_PATTERN("formatPattern", String.class),
         DATEFIELD_FORMATTER("dateFormatter", DateTimeFormatter.class);

--- a/src/main/java/org/numenta/nupic/encoders/DateEncoder.java
+++ b/src/main/java/org/numenta/nupic/encoders/DateEncoder.java
@@ -266,9 +266,9 @@ public class DateEncoder extends Encoder<DateTime> {
                     .w((int) hourOfWeek.get(0))
                     .radius((double) hourOfWeek.get(1))
                     .minVal(0)
-                    .maxVal(24)
+                    .maxVal(169)
                     .periodic(true)
-                    .name("time of day")
+                    .name("hour of week")
                     .forced(this.isForced())
                     .build();
             addChildEncoder(hourOfWeekEncoder);
@@ -710,9 +710,8 @@ public class DateEncoder extends Encoder<DateTime> {
         //  late night, etc.
         protected Tuple timeOfDay = new Tuple(0, 4.0);
 
-        // Value is time of day in hours
-        // Radius = 4 hours, e.g. morning, afternoon, evening, early night,
-        //  late night, etc.
+        // Value is hours since 00:00 Monday
+        // Radius = 24 hours
         protected Tuple hourOfWeek = new Tuple(0, 24.0);
         
         protected DateTimeFormatter customFormatter;

--- a/src/main/java/org/numenta/nupic/encoders/DateEncoder.java
+++ b/src/main/java/org/numenta/nupic/encoders/DateEncoder.java
@@ -74,6 +74,10 @@ import org.numenta.nupic.util.Tuple;
  *
  * forced (default True) : if True, skip checks for parameters' settings; see {@code ScalarEncoders} for details
  *
+ * hourOfWeek (00:00 Monday = 0; units = hour)
+ * (int) width of attribute: default radius = 24 hours
+ * (tuple) hourOfWeek[0] = width; hourOfWeek[1] = radius
+ *
  * @author utensil
  *
  * TODO Improve the document:
@@ -106,6 +110,9 @@ public class DateEncoder extends Encoder<DateTime> {
 
     protected Tuple timeOfDay;
     protected ScalarEncoder timeOfDayEncoder;
+
+    protected Tuple hourOfWeek;
+    protected ScalarEncoder hourOfWeekEncoder;
 
     protected List<Integer> customDaysList = new ArrayList<>();
 
@@ -160,7 +167,7 @@ public class DateEncoder extends Encoder<DateTime> {
         setForced(true);
 
         // Note: The order of adding encoders matters, must be in the following
-        // season, dayOfWeek, weekend, customDays, holiday, timeOfDay
+        // season, dayOfWeek, weekend, customDays, holiday, timeOfDay, hourOfWeek
 
         if(isValidEncoderPropertyTuple(season)) {
             seasonEncoder = ScalarEncoder.builder()
@@ -252,6 +259,19 @@ public class DateEncoder extends Encoder<DateTime> {
                     .forced(this.isForced())
                     .build();
             addChildEncoder(timeOfDayEncoder);
+        }
+
+        if(isValidEncoderPropertyTuple(hourOfWeek)) {
+            hourOfWeekEncoder = ScalarEncoder.builder()
+                    .w((int) hourOfWeek.get(0))
+                    .radius((double) hourOfWeek.get(1))
+                    .minVal(0)
+                    .maxVal(24)
+                    .periodic(true)
+                    .name("time of day")
+                    .forced(this.isForced())
+                    .build();
+            addChildEncoder(hourOfWeekEncoder);
         }
     }
 
@@ -362,6 +382,14 @@ public class DateEncoder extends Encoder<DateTime> {
 
     public void setTimeOfDay(Tuple timeOfDay) {
         this.timeOfDay = timeOfDay;
+    }
+
+    public Tuple getHourOfWeek() {
+        return hourOfWeek;
+    }
+
+    public void setHourOfWeek(Tuple hourOfWeek) {
+        this.hourOfWeek = hourOfWeek;
     }
 
     /**
@@ -515,6 +543,10 @@ public class DateEncoder extends Encoder<DateTime> {
         // The day of week was 1 based, so convert to 0 based
         int dayOfWeek = inputData.getDayOfWeek() - 1; // + timeOfDay / 24.0
 
+        double hourOfWeek = (24.0 * dayOfWeek) + inputData.getHourOfDay()
+                + inputData.getMinuteOfHour() / 60.0
+                + inputData.getSecondOfMinute() / 3600.0;
+
         if(seasonEncoder != null) {
             // The day of year was 1 based, so convert to 0 based
             double dayOfYear = inputData.getDayOfYear() - 1;
@@ -584,6 +616,10 @@ public class DateEncoder extends Encoder<DateTime> {
 
         if(timeOfDayEncoder != null) {
             values.add(timeOfDay);
+        }
+
+        if(hourOfWeekEncoder != null) {
+            values.add(hourOfWeek);
         }
 
         return values;
@@ -673,6 +709,11 @@ public class DateEncoder extends Encoder<DateTime> {
         // Radius = 4 hours, e.g. morning, afternoon, evening, early night,
         //  late night, etc.
         protected Tuple timeOfDay = new Tuple(0, 4.0);
+
+        // Value is time of day in hours
+        // Radius = 4 hours, e.g. morning, afternoon, evening, early night,
+        //  late night, etc.
+        protected Tuple hourOfWeek = new Tuple(0, 24.0);
         
         protected DateTimeFormatter customFormatter;
 
@@ -698,6 +739,7 @@ public class DateEncoder extends Encoder<DateTime> {
             e.setWeekend(this.weekend);
             e.setHoliday(this.holiday);
             e.setTimeOfDay(this.timeOfDay);
+            e.setHourOfWeek(this.hourOfWeek);
             e.setCustomDays(this.customDays);
             e.setCustomFormat(this.customFormatter);
 
@@ -795,6 +837,21 @@ public class DateEncoder extends Encoder<DateTime> {
          */
         public DateEncoder.Builder timeOfDay(int timeOfDay) {
             return this.timeOfDay(timeOfDay, (double) this.timeOfDay.get(1));
+        }
+
+        /**
+         * Set how many bits are used to encode hourOfWeek
+         */
+        public DateEncoder.Builder hourOfWeek(int hourOfWeek, double radius) {
+            this.hourOfWeek = new Tuple(hourOfWeek, radius);
+            return this;
+        }
+
+        /**
+         * Set how many bits are used to encode hourOfWeek
+         */
+        public DateEncoder.Builder hourOfWeek(int hourOfWeek) {
+            return this.hourOfWeek(hourOfWeek, (double) this.hourOfWeek.get(1));
         }
 
         /**

--- a/src/main/java/org/numenta/nupic/encoders/MultiEncoderAssembler.java
+++ b/src/main/java/org/numenta/nupic/encoders/MultiEncoderAssembler.java
@@ -104,7 +104,8 @@ public class MultiEncoderAssembler {
                 
                 if(!key.equals("season") && !key.equals("dayOfWeek") &&
                     !key.equals("weekend") && !key.equals("holiday") &&
-                    !key.equals("timeOfDay") && !key.equals("customDays") && 
+                    !key.equals("timeOfDay") && !key.equals("hourOfWeek")
+                        && !key.equals("customDays") &&
                     !key.equals("formatPattern") && !key.equals("dateFormatter")) {
                 
                     multiEncoder.setValue(b, key, dateEncoderSettings.get(key));
@@ -168,6 +169,14 @@ public class MultiEncoderAssembler {
                     b.timeOfDay((int)t.get(0), (double)t.get(1));
                 }else{
                     b.timeOfDay((int)t.get(0));
+                }
+                break;
+            }
+            case "hourOfWeek" : {
+                if(t.size() > 1 && ((double)t.get(1)) > 0.0) {
+                    b.hourOfWeek((int)t.get(0), (double)t.get(1));
+                }else{
+                    b.hourOfWeek((int)t.get(0));
                 }
                 break;
             }

--- a/src/test/java/org/numenta/nupic/encoders/DateEncoderTest.java
+++ b/src/test/java/org/numenta/nupic/encoders/DateEncoderTest.java
@@ -224,6 +224,29 @@ public class DateEncoderTest {
     }
 
     /**
+     * tests hour of week separately
+     */
+    @Test
+    public void testHourOfWeek() {
+        //use of forced is not recommended, used here for readability, see ScalarEncoder
+        DateEncoder e = DateEncoder.builder().hourOfWeek(21,24).forced(true).build();
+        int [] holiday = new int[]{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+                1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+                0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        //in the middle of fall, Thursday, not a weekend, afternoon - 4th Nov, 2010, 14:55
+
+        DateTime d = new DateTime(2010, 11, 4, 14, 55);
+        System.out.println(String.format("enc:%s", Arrays.toString(e.encode(d))));
+        System.out.println(String.format("exp:%s", Arrays.toString(holiday)));
+        assertArrayEquals(holiday, e.encode(d));
+
+    }
+
+    /**
      * Test weekend encoder
      */
     @Test


### PR DESCRIPTION
Fixes #358. hourOfWeek encoder is a copy of timeOfDay, using 168 as a max value and calculating a floating point input to its periodic scalar encoder, which is the number of hours since 00:00 on Monday (to the nearest second).