### PR TITLE
Moving dependency from .classpath and libs directory to maven pom.xml

### DIFF
--- a/.project
+++ b/.project
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>htm.java</name>
+	<name>mandarx</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
-		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-	</buildSpec>
-	<natures>
-		<nature>org.springsource.ide.eclipse.gradle.core.nature</nature>
-		<nature>org.eclipse.jdt.core.javanature</nature>
-	</natures>
+        <buildCommand>
+            <name>org.eclipse.jdt.core.javabuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>org.eclipse.jdt.core.javanature</nature>
+    </natures>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
+			<version>1.11.3</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,10 @@
 			<version>1.0.10</version>
 			<scope />
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
-			<version>1.11.3</version>
+			<version>1.5.1</version>
 		</dependency>
 	</dependencies>
 
@@ -248,4 +248,5 @@
 			</build>
 		</profile>
 	</profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
-			<version>1.5.1</version>
+			<version>1.11.3</version>
 		</dependency>
 	</dependencies>
 

--- a/src/test/java/org/numenta/nupic/monitor/mixin/MetricsTraceTest.java
+++ b/src/test/java/org/numenta/nupic/monitor/mixin/MetricsTraceTest.java
@@ -1,0 +1,41 @@
+package org.numenta.nupic.monitor.mixin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.numenta.nupic.Connections;
+import org.numenta.nupic.Parameters;
+import org.numenta.nupic.algorithms.TemporalMemory;
+import org.numenta.nupic.monitor.MonitoredTemporalMemory;
+
+
+public class MetricsTraceTest {
+
+    @Test
+    public void testPrettyPrintDatum() {
+        Parameters parameters = Parameters.getAllDefaultParameters();
+        Connections connections = new Connections();
+        parameters.apply(connections);
+        
+        TemporalMemory temporalMemory = new TemporalMemory();
+        temporalMemory.init(connections);
+        MonitoredTemporalMemory monitoredTM = new MonitoredTemporalMemory(temporalMemory, connections);
+        
+        Metric metric = new Metric(monitoredTM, "Test", Arrays.asList(2.3, 3.4, 5.5, 6.6, 7.7));
+        
+        MetricsTrace trace = null;
+        String traceData = null;
+        try {
+            trace = new MetricsTrace(monitoredTM, "Test");
+            traceData = trace.prettyPrintDatum(metric);
+        }catch(Exception e) {
+            fail();
+        }
+                        
+        assertEquals("min: 2.30, max: 7.70, sum: 25.50, mean: 5.10, std dev: 1.99", traceData);
+    }
+
+}


### PR DESCRIPTION
Fixes #388 
Making this change, to make org.numenta.nupic.network.LayerTest, run on any IDE. LayerTest was failing on Intellij Idea, due to missing dependency. Now, we can potentially clean up jmh-core dependency from .classpath file and libs directory.