### PR TITLE
Incremented version of the gradle shadow plugin to 1.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ buildscript {
    
    dependencies {
       classpath 'me.champeau.gradle:jmh-gradle-plugin:0.1.3'
-      classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
+      classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
       classpath 'org.openjdk.jmh:jmh-generator-annprocess:1.5.2'
    }
 }


### PR DESCRIPTION
Fixes #392
Incremented version of the gradle shadow plugin to 1.2.3, which contains a fix for compatibility with gradle 2.11 and higher.
