### PR TITLE
Simply added Locale.US to ensure dot decimals

### DIFF
--- a/src/main/java/org/numenta/nupic/monitor/mixin/MetricsTrace.java
+++ b/src/main/java/org/numenta/nupic/monitor/mixin/MetricsTrace.java
@@ -34,7 +34,7 @@ public class MetricsTrace extends Trace<Double> {
     }
 
     public String prettyPrintDatum(Metric datum) {
-        return String.format("min: %.2f, max: %.2f, sum: %.2f, mean: %.2f, std dev: %.2f", 
+        return String.format(Locale.US, "min: %.2f, max: %.2f, sum: %.2f, mean: %.2f, std dev: %.2f", 
             datum.min, datum.max, datum.sum, datum.mean, datum.standardDeviation);
     }
 }


### PR DESCRIPTION
This test failed on my machine due to the JVM using local decimal punctuation, which in my case was comma instead of the necessary dot to pass.