### PR TITLE
Fixes #394

### DIFF
--- a/src/main/java/org/numenta/nupic/monitor/mixin/MetricsTrace.java
+++ b/src/main/java/org/numenta/nupic/monitor/mixin/MetricsTrace.java
@@ -20,7 +20,7 @@
  * ---------------------------------------------------------------------
  */
 package org.numenta.nupic.monitor.mixin;
-
+import java.util.Locale;
 /**
  * Each entry contains {@link Metrics} (for example metric for # of predicted => active
  * cells).

--- a/src/main/java/org/numenta/nupic/monitor/mixin/MetricsTrace.java
+++ b/src/main/java/org/numenta/nupic/monitor/mixin/MetricsTrace.java
@@ -34,7 +34,7 @@ public class MetricsTrace extends Trace<Double> {
     }
 
     public String prettyPrintDatum(Metric datum) {
-        return String.format("min: %.2f, max: %.2f, sum: %.2f, mean: %.2f, std dev: %.2f", 
+        return String.format(Locale.US, "min: %.2f, max: %.2f, sum: %.2f, mean: %.2f, std dev: %.2f", 
             datum.min, datum.max, datum.sum, datum.mean, datum.standardDeviation);
     }
 }


### PR DESCRIPTION
Fixes #394
Added Locale.US to ensure that the tests were executed using dot decimal punctuation instead of whatever the local JVM decided to use.