### PR TITLE
Slight persistence patch and HTMObjectIn/Output constructor change.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 apply plugin: 'signing'
 
 group = 'org.numenta'
-version = '0.6.7'
+version = '0.6.8'
 archivesBaseName = 'htm.java'
 
 sourceCompatibility = 1.8
@@ -12,7 +12,7 @@ targetCompatibility = 1.8
 
 jar {
     manifest {
-        attributes 'Implementation-Title': 'htm.java', 'Implementation-Version': '0.6.7'
+        attributes 'Implementation-Title': 'htm.java', 'Implementation-Version': '0.6.8'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 apply plugin: 'signing'
 
 group = 'org.numenta'
-version = '0.6.7-SNAPSHOT'
+version = '0.6.7'
 archivesBaseName = 'htm.java'
 
 sourceCompatibility = 1.8
@@ -12,7 +12,7 @@ targetCompatibility = 1.8
 
 jar {
     manifest {
-        attributes 'Implementation-Title': 'htm.java', 'Implementation-Version': '0.6.7-SNAPSHOT'
+        attributes 'Implementation-Title': 'htm.java', 'Implementation-Version': '0.6.7'
     }
 }
 
@@ -28,10 +28,10 @@ test {
    outputs.upToDateWhen { false }
 }
 
-/* UNCOMMENT TO SEE STANDARD_OUT & STANDARD_ERR DURING BUILD
+/* UNCOMMENT TO SEE STANDARD_OUT & STANDARD_ERR DURING BUILD */
 test {
     testLogging.showStandardStreams = true
-}*/
+}
 
 dependencies {
     compile group: 'joda-time', name: 'joda-time', version: '2.5'
@@ -126,6 +126,7 @@ uploadArchives {
   javadoc.failOnError = false 
 
   if(!project.hasProperty('ossrhUsername')) {
+	println "returning from has Property false"
 	return
   } 
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,10 @@ test {
    outputs.upToDateWhen { false }
 }
 
-/* UNCOMMENT TO SEE STANDARD_OUT & STANDARD_ERR DURING BUILD */
+/* UNCOMMENT TO SEE STANDARD_OUT & STANDARD_ERR DURING BUILD
 test {
     testLogging.showStandardStreams = true
-}
+}*/
 
 dependencies {
     compile group: 'joda-time', name: 'joda-time', version: '2.5'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.numenta</groupId>
 	<artifactId>htm.java</artifactId>
-	<version>0.6.7</version>
+	<version>0.6.8</version>
 	<name>htm.java</name>
 	<description>The Java version of Numenta's HTM technology</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.numenta</groupId>
 	<artifactId>htm.java</artifactId>
-	<version>0.6.7-SNAPSHOT</version>
+	<version>0.6.7</version>
 	<name>htm.java</name>
 	<description>The Java version of Numenta's HTM technology</description>
 

--- a/src/main/java/org/numenta/nupic/network/Network.java
+++ b/src/main/java/org/numenta/nupic/network/Network.java
@@ -272,7 +272,13 @@ public class Network implements Persistable {
     public Network preSerialize() {
         if(shouldDoHalt && isThreadRunning) {
             halt();
+        }else{ // Make sure "close()" has been called on the Network
+            if(regions.size() == 1) {
+                this.tail = regions.get(0);
+            }
+            tail.close();
         }
+        
         regions.stream().forEach(r -> r.preSerialize());
         return this;
     }

--- a/src/main/java/org/numenta/nupic/network/Network.java
+++ b/src/main/java/org/numenta/nupic/network/Network.java
@@ -270,7 +270,7 @@ public class Network implements Persistable {
     @SuppressWarnings("unchecked")
     @Override
     public Network preSerialize() {
-        if(shouldDoHalt) {
+        if(shouldDoHalt && isThreadRunning) {
             halt();
         }
         regions.stream().forEach(r -> r.preSerialize());

--- a/src/main/java/org/numenta/nupic/serialize/HTMObjectInput.java
+++ b/src/main/java/org/numenta/nupic/serialize/HTMObjectInput.java
@@ -4,11 +4,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.numenta.nupic.Persistable;
+import org.nustaq.serialization.FSTConfiguration;
 import org.nustaq.serialization.FSTObjectInput;
 
 public class HTMObjectInput extends FSTObjectInput {
-    public HTMObjectInput(InputStream in) throws IOException {
-        super(in);
+    public HTMObjectInput(InputStream in, FSTConfiguration config) throws IOException {
+        super(in, config);
     }
     
     @SuppressWarnings("rawtypes")

--- a/src/main/java/org/numenta/nupic/serialize/HTMObjectOutput.java
+++ b/src/main/java/org/numenta/nupic/serialize/HTMObjectOutput.java
@@ -4,11 +4,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import org.numenta.nupic.Persistable;
+import org.nustaq.serialization.FSTConfiguration;
 import org.nustaq.serialization.FSTObjectOutput;
 
 public class HTMObjectOutput extends FSTObjectOutput {
-    public HTMObjectOutput(OutputStream out) {
-        super(out);
+    public HTMObjectOutput(OutputStream out, FSTConfiguration config) {
+        super(out, config);
     }
     
     @SuppressWarnings("rawtypes")

--- a/src/main/java/org/numenta/nupic/serialize/SerializerCore.java
+++ b/src/main/java/org/numenta/nupic/serialize/SerializerCore.java
@@ -104,7 +104,7 @@ public class SerializerCore implements Persistable {
      * @throws IOException 
      */
     public HTMObjectInput getObjectInput(InputStream is) throws IOException {
-        return new HTMObjectInput(is);
+        return new HTMObjectInput(is, fastSerialConfig);
     }
     
     /**
@@ -113,7 +113,7 @@ public class SerializerCore implements Persistable {
      * @return  the HTMObjectOutput
      */
     public <T extends Persistable> HTMObjectOutput getObjectOutput(OutputStream os) {
-        return new HTMObjectOutput(os);
+        return new HTMObjectOutput(os, fastSerialConfig);
     }
     
     /**

--- a/src/test/java/org/numenta/nupic/serialize/HTMObjectInputOutputTest.java
+++ b/src/test/java/org/numenta/nupic/serialize/HTMObjectInputOutputTest.java
@@ -1,0 +1,79 @@
+package org.numenta.nupic.serialize;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Test;
+import org.numenta.nupic.Parameters;
+import org.numenta.nupic.Parameters.KEY;
+import org.numenta.nupic.algorithms.Anomaly;
+import org.numenta.nupic.algorithms.SpatialPooler;
+import org.numenta.nupic.algorithms.TemporalMemory;
+import org.numenta.nupic.network.Network;
+import org.numenta.nupic.network.NetworkTestHarness;
+import org.numenta.nupic.network.Persistence;
+import org.numenta.nupic.network.PublisherSupplier;
+import org.numenta.nupic.network.sensor.ObservableSensor;
+import org.numenta.nupic.network.sensor.Sensor;
+import org.numenta.nupic.network.sensor.SensorParams;
+import org.numenta.nupic.network.sensor.SensorParams.Keys;
+import org.numenta.nupic.util.FastRandom;
+
+
+public class HTMObjectInputOutputTest {
+
+    @Test
+    public void testRoundTrip() {
+        Network network = getLoadedHotGymNetwork();
+        SerializerCore serializer = Persistence.get().serializer();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        HTMObjectOutput writer = serializer.getObjectOutput(baos);
+        try {
+            writer.writeObject(network, Network.class);
+            writer.flush();
+            writer.close();
+        }catch(Exception e) {
+            fail();
+        }
+        
+        byte[] bytes = baos.toByteArray();
+        
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        try {
+            HTMObjectInput reader = serializer.getObjectInput(bais);
+            Network serializedNetwork = (Network)reader.readObject(Network.class);
+            assertNotNull(serializedNetwork);
+            assertTrue(serializedNetwork.equals(network));
+        }catch(Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private Network getLoadedHotGymNetwork() {
+        Parameters p = NetworkTestHarness.getParameters().copy();
+        p = p.union(NetworkTestHarness.getHotGymTestEncoderParams());
+        p.setParameterByKey(KEY.RANDOM, new FastRandom(42));
+
+        Sensor<ObservableSensor<String[]>> sensor = Sensor.create(
+            ObservableSensor::create, SensorParams.create(Keys::obs, new Object[] {"name", 
+                PublisherSupplier.builder()
+                .addHeader("timestamp, consumption")
+                .addHeader("datetime, float")
+                .addHeader("B").build() }));
+
+        Network network = Network.create("test network", p).add(Network.createRegion("r1")
+            .add(Network.createLayer("1", p)
+                .alterParameter(KEY.AUTO_CLASSIFY, true)
+                .add(Anomaly.create())
+                .add(new TemporalMemory())
+                .add(new SpatialPooler())
+                .add(sensor)));
+
+        return network;
+    }
+}


### PR DESCRIPTION
Fixes #417 
Fixes #418 

Support not halting the Network when serializing it during non-threaded use. This support is built in to the checkpointing mechanism so halt doesn't have to be called, but in the case where a library has its own checkpointing mechanism (i.e. Flink), this patch will support that use case if the Network is not in threaded mode. 

If the Network **is** in threaded mode then users are forced to use the built in checkpointing mechanism until such time as a need develops to allow some flexibility with that option.