### PR TITLE
Fixes #524

### DIFF
--- a/src/main/java/org/numenta/nupic/network/Layer.java
+++ b/src/main/java/org/numenta/nupic/network/Layer.java
@@ -21,6 +21,7 @@
  */
 package org.numenta.nupic.network;
 
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.ArrayList;
@@ -2011,7 +2012,7 @@ public class Layer<T> implements Persistable {
      * Starts this {@code Layer}'s thread
      */
     protected void startLayerThread() {
-        (LAYER_THREAD = new Thread("Sensor Layer [" + getName() + "] Thread") {
+        LAYER_THREAD = new Thread("Sensor Layer [" + getName() + "] Thread") {
 
             @SuppressWarnings("unchecked")
             public void run() {
@@ -2044,7 +2045,16 @@ public class Layer<T> implements Persistable {
                     }
                 });
             }
-        }).start();
+        };
+        
+        LAYER_THREAD.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
+			
+			@Override
+			public void uncaughtException(Thread t, Throwable e) {
+				notifyError(new RuntimeException("Unhandled Exception in "+LAYER_THREAD.getName(),e));
+			}
+		});
+        LAYER_THREAD.start();
     }
     
     /**

--- a/src/test/java/org/numenta/nupic/network/PersistenceAPITest.java
+++ b/src/test/java/org/numenta/nupic/network/PersistenceAPITest.java
@@ -49,6 +49,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.numenta.nupic.FieldMetaType;
 import org.numenta.nupic.Parameters;
@@ -97,6 +98,13 @@ public class PersistenceAPITest extends ObservableTestBase {
     /** Printer to visualize DayOfWeek printouts - SET TO TRUE FOR PRINTOUT */
     private BiFunction<Inference, Integer, Integer> dayOfWeekPrintout = createDayOfWeekInferencePrintout(false);
     
+    
+    @BeforeClass
+    public static void beforeClass(){
+    	// Sample data contains datetimes that are invalid in some timezones due to DST.
+    	// If UTC is forced, then test runs should yield the same result regardless of timezone
+    	System.setProperty("user.timezone", "UTC");
+    }
 
     @AfterClass
     public static void cleanUp() {


### PR DESCRIPTION
Notify observers of uncaught exceptions in layer thread, this will fail a test case when checkObserver is being called.
In the affected test case, force UTC timezone for a more consistent test experience.