### PR TITLE
separated integration tests #531

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /target
 htm.java.iml
 .pydevproject
+classes

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,13 @@ repositories {
 
 // COMMENT OUT TO SKIP TESTS WHEN CODE HASN'T CHANGED
 test {
-   outputs.upToDateWhen { false }
+    description = 'Runs only unit tests and excludes integration tests'
+    outputs.upToDateWhen { false }
+    useJUnit {
+        excludeCategories 'org.numenta.nupic.IntegrationTest'
+    }
 }
+
 
 // UNCOMMENT TO SEE STANDARD_OUT & STANDARD_ERR DURING BUILD
 /*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 09 13:58:59 PDT 2016
+#Sun Nov 05 11:00:16 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 			<groupId>com.chaschev</groupId>
 			<artifactId>chutils</artifactId>
 			<version>1.4</version>
-			<!--We're only interested in ASCIITable from this library, so exclude 
+			<!--We're only interested in ASCIITable from this library, so exclude
 				all transitive dependencies -->
 			<exclusions>
 				<exclusion>
@@ -159,9 +159,29 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.18.1</version>
+				<configuration>
+					<excludedGroups>org.numenta.nupic.IntegrationTest</excludedGroups>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.18.1</version>
+				<configuration>
+					<includes>
+						<include>**/*.java</include>
+					</includes>
+                    <groups>org.numenta.nupic.IntegrationTest</groups>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>

--- a/src/test/java/org/numenta/nupic/FieldMetaTypeTest.java
+++ b/src/test/java/org/numenta/nupic/FieldMetaTypeTest.java
@@ -9,10 +9,12 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.numenta.nupic.encoders.DateEncoder;
 import org.numenta.nupic.util.Tuple;
 
 
+@Category(IntegrationTest.class)
 public class FieldMetaTypeTest {
 
     /**

--- a/src/test/java/org/numenta/nupic/IntegrationTest.java
+++ b/src/test/java/org/numenta/nupic/IntegrationTest.java
@@ -1,0 +1,4 @@
+package org.numenta.nupic;
+
+public interface IntegrationTest {
+}

--- a/src/test/java/org/numenta/nupic/RegressionTest.java
+++ b/src/test/java/org/numenta/nupic/RegressionTest.java
@@ -1,0 +1,4 @@
+package org.numenta.nupic;
+
+public interface RegressionTest {
+}

--- a/src/test/java/org/numenta/nupic/encoders/CoordinateEncoderTest.java
+++ b/src/test/java/org/numenta/nupic/encoders/CoordinateEncoderTest.java
@@ -30,9 +30,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.numenta.nupic.IntegrationTest;
 import org.numenta.nupic.util.ArrayUtils;
 import org.numenta.nupic.util.Tuple;
-
+@Category(IntegrationTest.class)
 public class CoordinateEncoderTest {
 	private CoordinateEncoder ce;
 	private CoordinateEncoder.Builder builder;

--- a/src/test/java/org/numenta/nupic/encoders/GeospatialCoordinateEncoderTest.java
+++ b/src/test/java/org/numenta/nupic/encoders/GeospatialCoordinateEncoderTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.numenta.nupic.util.ArrayUtils;
 import org.numenta.nupic.util.Tuple;
 

--- a/src/test/java/org/numenta/nupic/integration/ExtensiveTemporalMemoryTest.java
+++ b/src/test/java/org/numenta/nupic/integration/ExtensiveTemporalMemoryTest.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.numenta.nupic.IntegrationTest;
 import org.numenta.nupic.Parameters;
 import org.numenta.nupic.Parameters.KEY;
 import org.numenta.nupic.datagen.PatternMachine;
@@ -206,6 +208,7 @@ import org.numenta.nupic.monitor.mixin.Metric;
  * @see AbstractTemporalMemoryTest
  * @see BasicTemporalMemoryTest
  */
+@Category(IntegrationTest.class)
 public class ExtensiveTemporalMemoryTest extends AbstractTemporalMemoryTest {
     private static final PatternMachine PATTERN_MACHINE = new PatternMachine(100, 23, 300, true);
     

--- a/src/test/java/org/numenta/nupic/network/NetworkTest.java
+++ b/src/test/java/org/numenta/nupic/network/NetworkTest.java
@@ -38,6 +38,8 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.numenta.nupic.IntegrationTest;
 import org.numenta.nupic.Parameters;
 import org.numenta.nupic.Parameters.KEY;
 import org.numenta.nupic.algorithms.Anomaly;
@@ -64,6 +66,7 @@ import rx.Subscriber;
 import rx.observers.TestObserver;
 
 
+@Category(IntegrationTest.class)
 public class NetworkTest extends ObservableTestBase {
     private int[][] dayMap = new int[][] { 
         new int[] { 1, 1, 0, 0, 0, 0, 0, 1 }, // Sunday

--- a/src/test/java/org/numenta/nupic/network/PersistenceAPITest.java
+++ b/src/test/java/org/numenta/nupic/network/PersistenceAPITest.java
@@ -51,7 +51,9 @@ import java.util.stream.Stream;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.numenta.nupic.FieldMetaType;
+import org.numenta.nupic.IntegrationTest;
 import org.numenta.nupic.Parameters;
 import org.numenta.nupic.Parameters.KEY;
 import org.numenta.nupic.algorithms.Anomaly;
@@ -93,6 +95,7 @@ import rx.Subscriber;
 import rx.observers.TestObserver;
 
 
+@Category(IntegrationTest.class)
 public class PersistenceAPITest extends ObservableTestBase {
     // TO TURN ON PRINTOUT: SET "TRUE" BELOW
     /** Printer to visualize DayOfWeek printouts - SET TO TRUE FOR PRINTOUT */


### PR DESCRIPTION
`gradle test` now runs all tests except those tagged with `Category(IntegrationTest.class)`
`gradle check` runs all tests as before

`mvn test` now runs all tests except those tagged with `Category(IntegrationTest.class)`
`mvn integration-test` / `mvn verify` runs all tests

`gradle test` now runs in ~16 seconds.