### PR TITLE
Make junit tests results locale independent

### DIFF
--- a/src/test/java/org/numenta/nupic/BitHistoryTest.java
+++ b/src/test/java/org/numenta/nupic/BitHistoryTest.java
@@ -3,6 +3,7 @@ package org.numenta.nupic;
 import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.Method;
+import java.text.DecimalFormat;
 
 import org.junit.Test;
 import org.numenta.nupic.algorithms.BitHistory;
@@ -19,7 +20,8 @@ public class BitHistoryTest {
             m.setAccessible(true);
             double[] da = { 2.0, 4.0 };
             String output = (String)m.invoke(history, da);
-            assertEquals("[ 2.00 4.00 ]", output);
+            char decimalSeparator = new DecimalFormat().getDecimalFormatSymbols().getDecimalSeparator();
+            assertEquals("[ 2"+decimalSeparator+"00 4"+decimalSeparator+"00 ]", output);
         }catch(Exception e) {
             e.printStackTrace();
         }

--- a/src/test/java/org/numenta/nupic/monitor/mixin/MonitoredTemporalMemoryTest.java
+++ b/src/test/java/org/numenta/nupic/monitor/mixin/MonitoredTemporalMemoryTest.java
@@ -2,10 +2,12 @@ package org.numenta.nupic.monitor.mixin;
 
 import static org.junit.Assert.assertTrue;
 
+import java.text.DecimalFormat;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.numenta.nupic.Parameters;
 import org.numenta.nupic.Parameters.KEY;
@@ -24,6 +26,7 @@ public class MonitoredTemporalMemoryTest {
         MonitoredTemporalMemory mtm = new MonitoredTemporalMemory(new TemporalMemory(), new Connections());
         prepConstructs((TemporalMemory)mtm.getMonitor(), mtm.getConnections());
         
+        char decimalSeparator = new DecimalFormat().getDecimalFormatSymbols().getDecimalSeparator();
         String expected =
             "Segments: (format => (#) [(source cell=permanence ...),       ...]\n" +
             "------------------------------------\n" +
@@ -32,14 +35,14 @@ public class MonitoredTemporalMemoryTest {
             "Column   0 / Cell   2:\t(0) []\n" +
             "Column   0 / Cell   3:\t(0) []\n\n" +
             
-            "Column   1 / Cell   4:\t(1) [(  0=0.60   1=0.60   2=0.60   3=0.60)]\n" +
+            "Column   1 / Cell   4:\t(1) [(  0=0"+decimalSeparator+"60   1=0"+decimalSeparator+"60   2=0"+decimalSeparator+"60   3=0"+decimalSeparator+"60)]\n" +
             "Column   1 / Cell   5:\t(0) []\n" +
             "Column   1 / Cell   6:\t(0) []\n" +
             "Column   1 / Cell   7:\t(0) []\n" +
             "------------------------------------";
         
         String s = mtm.mmPrettyPrintConnections().trim();
-        assertTrue(expected.equals(s));
+        Assert.assertEquals(expected, s);
     }
     
     public void prepConstructs(TemporalMemory tm, Connections cn) {


### PR DESCRIPTION
I fix some junit tests because they fall on systems with different locale (with different Decimal Separator). Another option would be change mmPrettyPrintConnections output to always contains dots between decimals and whole numbers. see http://brilliantmaps.com/decimals/ ;)