### PR TITLE
Apply optimize stream refactoring.

### DIFF
--- a/src/main/java/org/numenta/nupic/model/Connections.java
+++ b/src/main/java/org/numenta/nupic/model/Connections.java
@@ -1553,7 +1553,7 @@ public class Connections implements Persistable {
      * @return  Synapse object on the segment with the minimal permanence
      */
     private Synapse minPermanenceSynapse(DistalDendrite dd) {
-        List<Synapse> synapses = getSynapses(dd).stream().sorted().collect(Collectors.toList());
+        List<Synapse> synapses = getSynapses(dd).parallelStream().sorted().collect(Collectors.toList());
         Synapse min = null;
         double minPermanence = Double.MAX_VALUE;
         

--- a/src/main/java/org/numenta/nupic/network/sensor/FileSensor.java
+++ b/src/main/java/org/numenta/nupic/network/sensor/FileSensor.java
@@ -157,7 +157,7 @@ public class FileSensor implements Sensor<File>, Serializable {
             innerPath = innerPath.startsWith("!") ? innerPath.substring(1) : innerPath;
             InputStream inStream = jar.getInputStream(jar.getEntry(innerPath));
             BufferedReader br = new BufferedReader(new InputStreamReader(inStream));
-            retVal = br.lines().onClose(() -> {
+            retVal = br.lines().parallel().onClose(() -> {
                 try {
                     br.close();
                     jar.close();

--- a/src/main/java/org/numenta/nupic/util/GroupBy2.java
+++ b/src/main/java/org/numenta/nupic/util/GroupBy2.java
@@ -237,7 +237,7 @@ public class GroupBy2<R extends Comparable<R>> implements Generator<Tuple> {
      * @return  the next smallest generated key.
      */
     private boolean nextMinKey() {
-        return Arrays.stream(nextList)
+        return Arrays.stream(nextList).parallel()
             .filter(opt -> opt.isPresent())
             .map(opt -> opt.get().getSecond())
             .min((k, k2) -> k.compareTo(k2))

--- a/src/main/java/org/numenta/nupic/util/UniversalRandom.java
+++ b/src/main/java/org/numenta/nupic/util/UniversalRandom.java
@@ -354,7 +354,7 @@ public class UniversalRandom extends Random {
         int[] selectedIndices = new int[sampleSize];
         List<Integer> collectedRandoms = new ArrayList<>();
         int[] expectedSample = {1,2,3,7,8,9};
-        List<Integer> expectedRandoms = Arrays.stream(new int[] {0,0,0,5,3,3}).boxed().collect(Collectors.toList());
+        List<Integer> expectedRandoms = Arrays.stream(new int[] {0,0,0,5,3,3}).parallel().boxed().collect(Collectors.toList());
         random.sampleWithPrintout(choices, selectedIndices, collectedRandoms);
         System.out.println("samples are equal ? " + Arrays.equals(expectedSample, selectedIndices));
         System.out.println("used randoms are equal ? " + collectedRandoms.equals(expectedRandoms));

--- a/src/test/java/org/numenta/nupic/QuickDayTest.java
+++ b/src/test/java/org/numenta/nupic/QuickDayTest.java
@@ -248,7 +248,7 @@ public class QuickDayTest {
             ComputeCycle cc = temporalMemory.compute(memory, input, true);
             lastPredicted = predictedColumns;
             predictedColumns = getSDR(cc.predictiveCells()); //Get the predicted column indexes
-            int[] activeCellIndexes = Connections.asCellIndexes(cc.activeCells()).stream().mapToInt(i -> i).sorted().toArray();  //Get the active cells for classifier input
+            int[] activeCellIndexes = Connections.asCellIndexes(cc.activeCells()).parallelStream().mapToInt(i -> i).sorted().toArray();  //Get the active cells for classifier input
             System.out.println("TemporalMemory Input = " + Arrays.toString(input));
             System.out.println("TemporalMemory Prediction = " + Arrays.toString(predictedColumns));
 

--- a/src/test/java/org/numenta/nupic/RunLayer.java
+++ b/src/test/java/org/numenta/nupic/RunLayer.java
@@ -214,7 +214,7 @@ public class RunLayer {
         public Tuple tmStep(int[] sparseSPOutput, boolean learn, boolean isVerbose) {
             // Input into the Temporal Memory
             ComputeCycle cc = tm.compute(connections, sparseSPOutput, learn);
-            int[] activeCellIndices = cc.activeCells().stream().mapToInt(c -> c.getIndex()).sorted().toArray();
+            int[] activeCellIndices = cc.activeCells().parallelStream().mapToInt(c -> c.getIndex()).sorted().toArray();
             int[] predColumnIndices = SDR.cellsAsColumnIndices(cc.predictiveCells(), connections.getCellsPerColumn());
             int[] activeColumns = Arrays.stream(activeCellIndices)
                 .map(cell -> cell / connections.getCellsPerColumn())
@@ -478,7 +478,7 @@ public class RunLayer {
     }
     
     public static void loadSPOutputFile() {
-        try (Stream<String> stream = Files.lines(Paths.get(MakeshiftLayer.readFile))) {
+        try (Stream<String> stream = Files.lines(Paths.get(MakeshiftLayer.readFile)).parallel()) {
             MakeshiftLayer.input = stream.map(l -> {
                 String line = l.replace("[", "").replace("]",  "").trim();
                 int[] result = Arrays.stream(line.split("[\\s]*\\,[\\s]*")).mapToInt(i -> Integer.parseInt(i)).toArray();
@@ -490,7 +490,7 @@ public class RunLayer {
     }
     
     public static void loadRawInputFile() {
-        try (Stream<String> stream = Files.lines(Paths.get(MakeshiftLayer.INPUT_PATH))) {
+        try (Stream<String> stream = Files.lines(Paths.get(MakeshiftLayer.INPUT_PATH)).parallel()) {
             MakeshiftLayer.raw = stream.map(l -> l.trim()).collect(Collectors.toList());
         }catch(Exception e) {e.printStackTrace();}
     }


### PR DESCRIPTION
We are in the process of evaluating a research project associated with an automated refactoring tool that attempts to optimize Java 8 streams for maximum performance. In the case of your project, it converted several streams to parallel. The tool is very conservative, meaning that the tool goes through an extensive static analysis to ensure that the transformation is safe, i.e., original program semantics have been preserved. However, this also means that the proposed changes can be a proper subset of all streams that can be optimized. We would appreciate any feedback on the change set that you have.

We found a JMH performance test in your project that does a quick test on a small dataset. To assess the increased parallelism, however, we altered this test to have a larger data set. The results show an overall speedup of ~1.09 (see below):

| SUM of Score | Mode/Unit |
|---|---|
|  | avgt |
| Benchmark | ms/op |
| org.numenta.nupic.benchmarks.SpatialPoolerGlobalInhibitionBenchmark.measureAvgCompute_7_Times | 1.026802509 |
| org.numenta.nupic.benchmarks.SpatialPoolerLocalInhibitionBenchmark.measureAvgCompute_7_Times | 1.088495208 |
| org.numenta.nupic.benchmarks.TemporalMemoryBenchmark.measureAvgCompute_7_Times | 0.9826161244 |
| Grand Total | 1.088169369 |

We have also pasted the patch to your JMH test suite that we used to increase the data set. Please let us know if you have any questions and again we appreciate any feedback!

```diff
diff --git a/src/jmh/java/org/numenta/nupic/benchmarks/AbstractAlgorithmBenchmark.java b/src/jmh/java/org/numenta/nupic/benchmarks/AbstractAlgorithmBenchmark.java
index 8a81d171d..4c978d47c 100644
--- a/src/jmh/java/org/numenta/nupic/benchmarks/AbstractAlgorithmBenchmark.java
+++ b/src/jmh/java/org/numenta/nupic/benchmarks/AbstractAlgorithmBenchmark.java
@@ -43,11 +43,11 @@ public abstract class AbstractAlgorithmBenchmark {
 
     @Setup
     public void init() {
-        SDR = new int[2048];
+        SDR = new int[40960];
 
         //Layer components
         ScalarEncoder.Builder dayBuilder = ScalarEncoder.builder()
-            .n(8)
+            .n(160)
             .w(3)
             .radius(1.0)
             .minVal(1.0)
@@ -76,9 +76,9 @@ public abstract class AbstractAlgorithmBenchmark {
      */
     protected Parameters getParameters() {
         Parameters parameters = Parameters.getAllDefaultParameters();
-        parameters.set(KEY.INPUT_DIMENSIONS, new int[] { 8 });
-        parameters.set(KEY.COLUMN_DIMENSIONS, new int[] { 2048 });
-        parameters.set(KEY.CELLS_PER_COLUMN, 32);
+        parameters.set(KEY.INPUT_DIMENSIONS, new int[] { 160 });
+        parameters.set(KEY.COLUMN_DIMENSIONS, new int[] { 40960 });
+        parameters.set(KEY.CELLS_PER_COLUMN, 640);
 
         //SpatialPooler specific
         parameters.set(KEY.POTENTIAL_RADIUS, 12);//3
diff --git a/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerGlobalInhibitionBenchmark.java b/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerGlobalInhibitionBenchmark.java
index 08fe1dea5..69e502db3 100644
--- a/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerGlobalInhibitionBenchmark.java
+++ b/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerGlobalInhibitionBenchmark.java
@@ -41,9 +41,9 @@ public class SpatialPoolerGlobalInhibitionBenchmark extends AbstractAlgorithmBen
     public void init() {
         super.init();
 
-        input = new int[7][8];
-        for(int i = 0;i < 7;i++) {
-            input[i] = encoder.encode((double) i + 1);
+        input = new int[140][160];
+        for(int i = 0;i < 140;i++) {
+            input[i] = encoder.encode((double) ((i % 7) + 1));
         }
     }
 
@@ -55,10 +55,10 @@ public class SpatialPoolerGlobalInhibitionBenchmark extends AbstractAlgorithmBen
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public int[] measureAvgCompute_7_Times(Blackhole bh) throws InterruptedException {
-        for(int i = 0;i < 7;i++) {
+        for(int i = 0;i < 140;i++) {
             pooler.compute(memory, input[i], SDR, true);
         }
 
diff --git a/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerLocalInhibitionBenchmark.java b/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerLocalInhibitionBenchmark.java
index 8bbe19698..f333aba40 100644
--- a/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerLocalInhibitionBenchmark.java
+++ b/src/jmh/java/org/numenta/nupic/benchmarks/SpatialPoolerLocalInhibitionBenchmark.java
@@ -39,17 +39,17 @@ public class SpatialPoolerLocalInhibitionBenchmark extends AbstractAlgorithmBenc
     public void init() {
         super.init();
 
-        input = new int[7][8];
-        for(int i = 0;i < 7;i++) {
-            input[i] = encoder.encode((double) i + 1);
+        input = new int[140][160];
+        for(int i = 0;i < 140;i++) {
+            input[i] = encoder.encode((double) ((i % 7) + 1));
         }
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
+    @BenchmarkMode(Mode.All)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public int[] measureAvgCompute_7_Times(Blackhole bh) throws InterruptedException {
-        for(int i = 0;i < 7;i++) {
+        for(int i = 0;i < 140;i++) {
             pooler.compute(memory, input[i], SDR, true);
         }
 
diff --git a/src/jmh/java/org/numenta/nupic/benchmarks/TemporalMemoryBenchmark.java b/src/jmh/java/org/numenta/nupic/benchmarks/TemporalMemoryBenchmark.java
index e6d13c4e0..d3440a674 100644
--- a/src/jmh/java/org/numenta/nupic/benchmarks/TemporalMemoryBenchmark.java
+++ b/src/jmh/java/org/numenta/nupic/benchmarks/TemporalMemoryBenchmark.java
@@ -44,31 +44,31 @@ public class TemporalMemoryBenchmark extends AbstractAlgorithmBenchmark {
         super.init();
 
         //Initialize the encoder's encoded output
-        input = new int[7][8];
-        for(int i = 0;i < 7;i++) {
-            input[i] = encoder.encode((double) i + 1);
+        input = new int[140][160];
+        for(int i = 0;i < 140;i++) {
+            input[i] = encoder.encode((double) ((i % 7) + 1));
         }
 
-        SDRs = new int[7][];
+        SDRs = new int[140][];
 
-        for(int i = 0;i < 7;i++) {
+        for(int i = 0;i < 140;i++) {
             pooler.compute(memory, input[i], SDR, true);
             SDRs[i] = ArrayUtils.where(SDR, ArrayUtils.WHERE_1);
         }
 
-        for(int j = 0;j < 100;j++) {
-            for(int i = 0;i < 7;i++) {
+        for(int j = 0;j < 2000;j++) {
+            for(int i = 0;i < 140;i++) {
                 temporalMemory.compute(memory, SDRs[i], true);
             }
         }
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
+    @BenchmarkMode(Mode.All)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public ComputeCycle measureAvgCompute_7_Times(Blackhole bh) throws InterruptedException {
         ComputeCycle cc = null;
-        for(int i = 0;i < 7;i++) {
+        for(int i = 0;i < 140;i++) {
             cc = temporalMemory.compute(memory, SDRs[i], true);
         }
```